### PR TITLE
Remove angle brackets from laptop display name

### DIFF
--- a/.config/sway/config.d/clamshell
+++ b/.config/sway/config.d/clamshell
@@ -1,5 +1,5 @@
 # Clamshell Mode
-set $laptop <eDP-1>
+set $laptop eDP-1
 bindswitch --reload --locked lid:on output $laptop disable
 bindswitch --reload --locked lid:off output $laptop enable
 

--- a/.config/sway/scripts/clamshell.sh
+++ b/.config/sway/scripts/clamshell.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 if cat /proc/acpi/button/lid/*/state | grep -q open; then
-    swaymsg output <eDP-1> enable
+    swaymsg output eDP-1 enable
 else
-    swaymsg output <eDP-1> disable
+    swaymsg output eDP-1 disable
 fi


### PR DESCRIPTION
Clamshell mode does not work out of the box. I think the existing clamshell script has included angle brackets in the display name when it should not have: https://github.com/swaywm/sway/wiki#clamshell-mode

> Replace `<LAPTOP>` with the name of the display.

I've removed the brackets and clamshell mode now works as expected.