### PR TITLE
Make screenshot case insensitive

### DIFF
--- a/.config/wofi/config.screenshot
+++ b/.config/wofi/config.screenshot
@@ -1,5 +1,6 @@
 hide_search=true
 hide_scroll=true
+insensitive=true
 width=1
 show=dmenu
 lines=5


### PR DESCRIPTION
Edit wofi config.screenshot to make the screenshot menu case insensitive.