### PR TITLE
Fix missing unit in waybar/style.css

### DIFF
--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -138,7 +138,7 @@ Arc-Dark Color Scheme
     border-bottom: 3px transparent;
     color:white;
     margin-left: 5px;
-    padding:7;
+    padding: 7px;
 }
 
 #network.disconnected {


### PR DESCRIPTION
There is a missing CSS unit in `.config/waybar/style.css` which is deprecated and causes a Gtk-warning.