### PR TITLE
Fix: Sway 1.8 changed "dpms" to "power"

### DIFF
--- a/.config/sway/config.d/default
+++ b/.config/sway/config.d/default
@@ -28,8 +28,8 @@ set $powermenu ~/.config/waybar/scripts/power-menu.sh
 ### Idle configuration
 exec swayidle -w\
     timeout 1070 'swaylock -f -C ~/.config/swaylock/config'\
-    timeout 770 'swaymsg "output * dpms off"' \
-    resume 'swaymsg "output * dpms on"' \
+    timeout 770 'swaymsg "output * power off"' \
+    resume 'swaymsg "output * power on"' \
     before-sleep 'swaylock -C ~/.config/swaylock/config'
 # This will lock your screen after 300 seconds of inactivity, then turn off
 # your displays after another 300 seconds, and turn your screens back on when

--- a/.config/sway/scripts/lockman.sh
+++ b/.config/sway/scripts/lockman.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Times the screen off and puts it to background
 swayidle \
-    timeout  300 'swaymsg "output * dpms off"' \
-    resume 'swaymsg "output * dpms on"' &
+    timeout  300 'swaymsg "output * power off"' \
+    resume 'swaymsg "output * power on"' &
 # Locks the screen immediately
 swaylock
 # Kills last background task so idle timer doesn't keep running


### PR DESCRIPTION
Sway 1.8 is currently in rc status, but I thought I would add this in preparation for it being released. `dpms` does still work, but it will be removed in a future version.

This change was added in swaywm/sway#7083. I'm somewhat disappointed that the Sway team decided to immediately deprecate `dpms` rather than leave both options.