### PR TITLE
check for acpi before getting lid state

### DIFF
--- a/.config/sway/scripts/clamshell.sh
+++ b/.config/sway/scripts/clamshell.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/bash
-if cat /proc/acpi/button/lid/*/state | grep -q open; then
-    swaymsg output eDP-1 enable
-else
-    swaymsg output eDP-1 disable
+if [-d "/proc/acpi" ]; then
+  if cat /proc/acpi/button/lid/*/state | grep -q open; then
+     swaymsg output eDP-1 enable
+  else
+     swaymsg output eDP-1 disable
+  fi
 fi


### PR DESCRIPTION
This should safeguard ARM-based machines that do not support ACPI and boot using a device tree. Tested on my X13s running EndeavourOS sway edition.  Otherwise we get a black screen when trying to run sway.