### PR TITLE
Fix screen-sharing for Firefox & Chromium

### DIFF
--- a/.config/sway/config
+++ b/.config/sway/config
@@ -5,6 +5,10 @@ exec ~/set_once.sh
 #
 # Read `man 5 sway` for a complete reference.
 
+# announce a running sway session to systemd
+exec systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
+exec dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP=sway
+
 # user config directory
 include $HOME/.config/sway/config.d/*
 


### PR DESCRIPTION
I had a problem on my install that I could not do screensharing in Firefox and Chromium, despite setting all the env vars launch arguments and `about:config`s and `chrome://flags` that I could find, in several places on my machine.

When going through the [**excellent** xdg-desktop-portal-wlr troubleshooting guide](https://github.com/emersion/xdg-desktop-portal-wlr/wiki/%22It-doesn't-work%22-Troubleshooting-Checklist), I found out that there was a problem with the xdg-desktop-portal. Instead of just exporting the XDG_CURRENT_DESKTOP env var, we need to explicitly pass it along to the systemd and dbus environments.

This fixes it on my machine and now I'm able to screenshare from both Firefox and Chromium (with Wayland env var and webrtc flags set)

Fix is done as per step 5 of https://github.com/emersion/xdg-desktop-portal-wlr/wiki/%22It-doesn't-work%22-Troubleshooting-Checklist
and points 1 and 2 in https://github.com/alebastr/sway-systemd/blob/0fdb2c4b10beb6079acd6073c5b3014bd58d3b74/src/session.sh