### PR TITLE
fix grimshot script filepath

### DIFF
--- a/.config/sway/config.d/default
+++ b/.config/sway/config.d/default
@@ -219,7 +219,7 @@ bindsym $mod+r mode "resize"
 #
 # Screenshots
 #
-    bindsym print exec /usr/share/sway/scripts/grimshot --notify save output
+    bindsym print exec /usr/share/sway-contrib/grimshot --notify save output
     bindsym Shift+print exec ~/.config/sway/scripts/screenshot.sh
 #
 # Keybindings List

--- a/.config/sway/scripts/screenshot.sh
+++ b/.config/sway/scripts/screenshot.sh
@@ -6,13 +6,13 @@ selected=$(printf '%s\n' $entries | wofi --style=$HOME/.config/wofi/style.widget
  
 case $selected in
   active)
-    /usr/share/sway-contrib/scripts/grimshot --notify save active;;
+    /usr/share/sway-contrib/grimshot --notify save active;;
   screen)
-    /usr/share/sway-contrib/scripts/grimshot --notify save screen;;
+    /usr/share/sway-contrib/grimshot --notify save screen;;
   output)
-    /usr/share/sway-contrib/scripts/grimshot --notify save output;;
+    /usr/share/sway-contrib/grimshot --notify save output;;
   area)
-    /usr/share/sway-contrib/scripts/grimshot --notify save area;;
+    /usr/share/sway-contrib/grimshot --notify save area;;
   window)
-    /usr/share/sway-contrib/scripts/grimshot --notify save window;;
+    /usr/share/sway-contrib/grimshot --notify save window;;
 esac


### PR DESCRIPTION
The grimshot script file path was pointing to a now non-existent location, which caused the screenshot tool to not work. I pointed to the correct path `/usr/share/sway-contrib/grimshot` in both `.config/sway/config.d/default` and `.config/sway/scripts/screenshot.sh` which resolved the issue.