### PR TITLE
Fix wofi colour typo and set window background to match

### DIFF
--- a/.config/wofi/style.css
+++ b/.config/wofi/style.css
@@ -4,7 +4,7 @@ Arc-Dark Color Scheme
 
 @define-color highlight #5294e2;
 @define-color base1  #404552;
-@define-color base2 #40455;
+@define-color base2 #404552;
 @define-color base3  #4b5160;
 
 *{
@@ -13,6 +13,7 @@ Arc-Dark Color Scheme
 
 window {
     border: 1px solid @highlight;
+    background-color: @base1;
 }
 
 #input {
@@ -20,7 +21,7 @@ window {
     padding:3px;
     border-radius: 5px;
     border:none;
-    color: white;
+    color: black;
 }
 
 #inner-box {


### PR DESCRIPTION
This PR fixes the style.css file for the wofi config.

It changes the look of wofi from this:

![satty-20240626-22:13:36](https://github.com/EndeavourOS-Community-Editions/sway/assets/427379/441abf0f-db45-4d19-ad5e-bdcca3e70bd8)

To this:

![satty-20240627-07:50:04](https://github.com/EndeavourOS-Community-Editions/sway/assets/427379/aef5243a-dfd7-497c-a0eb-909ff7238172)

I believe this was the intended look and feel for the wofi window since the background colour used was an invalid hex colour code.

Although you cannot see it in the screenshot, the original style sets the font colour to white, which makes the input text invisible (white on white), this was changed to black.
