### PR TITLE
feat(waybar): update pulseaudio module

### DIFF
--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -139,25 +139,19 @@
     },
 
     "pulseaudio": {
-        "scroll-step": 1, // %, can be a float
-        "format": "{volume}% {icon}",
-        "format-bluetooth": "{volume}% {icon}  {format_source}",
-        "format-bluetooth-muted": " {icon}  {format_source}",
-        "format-muted": "婢 {format_source}",
-        "format-source": "{volume}% ",
-        "format-source-muted": "",
+        "scroll-step": 2,
+        "format": "{icon} {volume}%",
+        "format-muted":"󰝟 muted",
         "format-icons": {
-            "headphone": "",
-            "hands-free": "וֹ",
-            "headset": "  ",
+            "headphones": "",
+            "handsfree": "",
+            "headset": "",
             "phone": "",
             "portable": "",
             "car": "",
-            "default": [""]
+            "default": ["󰕿", "󰖀", "󰕾"]
         },
-        "on-click": "pavucontrol",
-        "on-scroll-up": "pactl set-sink-volume @DEFAULT_SINK@ +2%",
-        "on-scroll-down": "pactl set-sink-volume @DEFAULT_SINK@ -2%",
+        "on-click": "pavucontrol"
     },
 
     // to use the weather module replace <your_location> with your city or town


### PR DESCRIPTION
* Set `scroll-step` to 2 and remove `on-scroll-up`/`on-scroll-down` action (which is doing the same thing)
* Format as icon|volume instead of volume|icon for consistency with other modules
* Remove `format-source` settings since it seems to be set up inconsistently. This feature also behaves oddly by default (for example, it cannot have an on-click or scroll behavior independent from volume--kind of unintuitive). If a user wants to use this feature it will likely work better to break out source into a separate module like this: https://github.com/Alexays/Waybar/issues/925#issuecomment-1377761376
* Remove `format-bluetooth` settings since it is not defining a different behavior after removing `format-source`
* Replaced , 婢, , and  icons since they are all depreciated/removed from Nerd Font icon set
* Added additional icons to `default` to have different icons for low, medium, and high volume settings