### PR TITLE
feat(waybar): add sway/window to modules-left

### DIFF
--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -10,6 +10,7 @@
         "custom/launcher",
         "sway/workspaces",
         "sway/mode",
+        "sway/window",
     ],
  
     "modules-center": [


### PR DESCRIPTION
Add sway/window module next to workspaces. It prints the title of the focused window in the Waybar.

![image](https://github.com/user-attachments/assets/242a6aad-d092-4f04-b40b-4a1df65eb4b3)
