### PR TITLE
feat(waybar): update keyboard module, update input config file

### DIFF
--- a/.config/sway/config.d/input
+++ b/.config/sway/config.d/input
@@ -1,20 +1,30 @@
 ### Input configuration
 #
-# Example configuration:
-# You can get the names of your inputs by running: swaymsg -t get_inputs
-# Put your touchpad's ID to replace "Touchpad-ID" (keep the quotation marks)
+# Read `man 5 sway-input` for more information about this section.
 
+# Touchpad configuration
 input type:touchpad {
     dwt enabled
     tap enabled
     natural_scroll enabled
 }
 
-# Read `man 5 sway-input` for more information about this section.
-#
-input type:keyboard xkb_layout "us"
+# Enable numlock by default
+input type:keyboard xkb_numlock enabled
 
+# Set keyboard layout and variant based on current system settings
 exec_always {
     'swaymsg input type:keyboard xkb_layout "$(localectl status | grep "X11 Layout" | sed -e "s/^.*X11 Layout://")"'
     'swaymsg input type:keyboard xkb_variant "$(localectl status | grep "X11 Variant" | sed -e "s/^.*X11 Variant://")"'
 }
+
+# # Toggle between keyboard layouts. This example has the "us" and "gb"
+# # keyboard layouts, and uses Alt+Shift to toggle between them.
+# input "type:keyboard" {
+#     xkb_layout "us,gb"
+#     xkb_options "grp:alt_shift_toggle"
+# }
+# # Assign the same binding to "pkill -RTMIN+1 waybar" to send signal to
+# # the Waybar keyboard module (so the module shows the updated layout).
+# # This example uses Alt + left Shift.
+# bindsym Alt+Shift_L exec "pkill -RTMIN+1 waybar"

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -79,13 +79,12 @@
     },
 
     "custom/keyboard-layout": {
-        "exec": "swaymsg -t get_inputs | grep -m1 'xkb_active_layout_name' | cut -d '\"' -f4",
-        // Interval set only as a fallback, as the value is updated by signal
+      	"exec": "i=$(swaymsg -t get_inputs); echo \"\"; echo \"$i\" | grep -m1 'xkb_active_layout_name' | cut -d '\"' -f4",
+        "format": "",
+        // Interval set only as a fallback; use signal to update the module more immediately
         "interval": 30,
-        "format": "  {}", // Icon: keyboard
-        // Signal sent by Sway key binding (~/.config/sway/key-bindings)
-        "signal": 1, // SIGHUP
-        "tooltip": false,
+        // See example config for sending signal to Waybar in ~/.config/sway/config.d/input
+        "signal": 1,
         "on-click": "~/.config/waybar/scripts/keyhint.sh",
     },
 


### PR DESCRIPTION
Update the Waybar keyboard module to move the keyboard layout to the tooltip when hovering over the module (and out of the actual Waybar).

![image](https://github.com/user-attachments/assets/6922e42a-d581-4855-97d0-ca4acf467609)

This will contribute to a cleaner look, and help trim down the lengthiness of the Waybar without sacrificing the utility of the module.

* Move keyboard layout to tooltip
* The module comments also referenced a script for sending signal, but there is no such script. The comments have been updated to reference example code added to ~/.config/sway/config.d/input

In addition to adding the example code, ~/.config/sway/config.d/input itself was updated to address some issues and add additional functionality.

* Remove the note about finding the touchpad ID and adding it to the config. This has not been necessary on Sway for a long time.
* Remove the `input type:keyboard xkb_layout "us"` line. This line is not actually doing anything since it will be overwritten by the `exec_always` block right below it every time Sway is reloaded.
* Enable numlock by default
* Add a commented block with example config for setting up keyboard layout toggle.
* Add explanatory comments.