### PR TITLE
Replaces Lxappearance to nwg-look and update README.md

### DIFF
--- a/.config/sway/config.d/application_defaults
+++ b/.config/sway/config.d/application_defaults
@@ -26,7 +26,7 @@ for_window [app_id="pavucontrol" ] floating enable, resize set width 40 ppt heig
 for_window [class="qt5ct" instance="qt5ct"] floating enable, resize set width 60 ppt height 50 ppt
 for_window [class="Bluetooth-sendto" instance="bluetooth-sendto"] floating enable
 for_window [app_id="pamac-manager"] floating enable, resize set width 80 ppt height 70 ppt
-for_window [class="Lxappearance"] floating enable, resize set width 60 ppt height 50 ppt
+for_window [app_id="nwg-look"] floating enable, resize set width 60 ppt height 50 ppt
 
 # set floating for window roles
 for_window [window_role="pop-up"] floating enable

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ https://forum.endeavouros.com/t/sway-edition-general-conversation
 ## Tutorial for sway-wm settings:
 
  - Background handled by swaybg
- - Gtk3 theme handled by lxappearance
+ - Gtk3 theme handled by nwg-look
  - Filebrowser = Thunar
  - Default Terminal-Emulator = Foot
  - Text-Editor = xed/nano

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## unmaintained needs contributors or maintainer
 
 * still working.. as it is fixed for the moment. joekamprad tested by installing it over the ISO script (June 2024)
-* https://github.com/EndeavourOS-Community-Editions/sway/blob/main/setup_sway_isomode.bash
+* https://raw.githubusercontent.com/EndeavourOS-Community-Editions/sway/main/setup_sway_isomode.bash
+* Read here on how to use it: https://github.com/EndeavourOS-Community-Editions/.github/blob/main/profile/README.md
 * [July 2024] start getting big fixes and changes from BluishHumility
   
 # Sway-WM Setup and Theme for EndeavourOS


### PR DESCRIPTION
In this PR: 

- Replaces Lxappearance to nwg-look in `.config/sway/config.d/application_defaults` and `README.md`

- Change the url to https://raw.githubusercontent.com/EndeavourOS-Community-Editions/sway/main/setup_sway_isomode.bash instead of https://github.com/EndeavourOS-Community-Editions/sway/blob/main/setup_sway_isomode.bash, so that beginners(like me :D) don't experience installation failure due to fetching the wrong URL and add “How to use it”