### PR TITLE
[URGENT] Fix autoscroll on browser with touchpad without having to touch the touchpad to scroll

### DIFF
--- a/.config/sway/config.d/input
+++ b/.config/sway/config.d/input
@@ -6,7 +6,7 @@
 input type:touchpad {
     dwt enabled
     tap enabled
-    tap_button_map lmr # Fixed autoscroll without having to scroll on browser (this thing is tested)
+    tap_button_map lrm # Fixed autoscroll without having to scroll on browser (this thing is tested) , right click menu was not showing up idk how this works but it supresses the autoscroll
     natural_scroll enabled
 }
 

--- a/.config/sway/config.d/input
+++ b/.config/sway/config.d/input
@@ -6,6 +6,7 @@
 input type:touchpad {
     dwt enabled
     tap enabled
+    tap_button_map lmr # Fixed autoscroll without having to scroll on browser (this thing is tested)
     natural_scroll enabled
 }
 


### PR DESCRIPTION
basically i installed sway and when i searched up something for example 'uwu' on the browser it basically automatically started scrolling to the bottom and when i tried to get it up by scrolling in the process it bugged so i added `tap_button_map lrm` in the thing so that it stops the auto scroll on the browser i tested it and it works great!