### PR TITLE
Use -e to set sway env when running dex autostart

### DIFF
--- a/.config/sway/config.d/autostart_applications
+++ b/.config/sway/config.d/autostart_applications
@@ -28,7 +28,7 @@ exec wl-paste --type text --watch cliphist store
 exec wl-paste --type image --watch cliphist store
      
 # Welcome App
-exec dex -a -s /etc/xdg/autostart/:~/.config/autostart/  
+exec dex -a -e sway -s /etc/xdg/autostart/:~/.config/autostart/  
 
 # Sway Fader
 # exec python3 ~/.config/sway/scripts/swayfader.py      


### PR DESCRIPTION
`dex` by default does not respect the .desktop file `OnlyShowIn` and `NotShowIn` directives.

This means that you get strange behaviour, for example, KDE Plasma components launching alongside Sway, when Dex runs.

This only impacts systems with multiple DEs installed, but this seems to be the 'right' thing to do. 

From the manpage:
> -e ENVIRONMENT, --environment ENVIRONMENT
>              Specify  the  Desktop  Environment  an autostart should be performed for; works only in combination with --autostart