### PR TITLE
feat: add support for nvidia installations

### DIFF
--- a/setup_sway_isomode.bash
+++ b/setup_sway_isomode.bash
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
 username="$1"
 
-# # Clone the repo
-# echo "Cloning the EOS Community Sway repo..."
-# git clone https://github.com/EndeavourOS-Community-Editions/sway.git
-
-# Clone the nvidia-testing branch of the repo
-echo "Cloning the EOS Community Sway repo (nvidia-testing branch)..."
-git clone --branch nvidia-testing https://github.com/EndeavourOS-Community-Editions/sway.git
+# Clone the repo
+echo "Cloning the EOS Community Sway repo..."
+git clone https://github.com/EndeavourOS-Community-Editions/sway.git
 
 # Check if nvidia-inst is installed
 # If it is, do the Nvidia stuff

--- a/setup_sway_isomode.bash
+++ b/setup_sway_isomode.bash
@@ -15,6 +15,7 @@ if pacman -Qq nvidia-inst 2>/dev/null | grep -q .; then
     # Add the --unsupported-gpu flag to the sway call in greetd.conf
     sed -i 's|sway -c|sway --unsupported-gpu -c|' sway/etc/greetd/greetd.conf
     # Create a custom desktop file that uses sway --unsupported-gpu
+    mkdir -p /usr/share/wayland-sessions
     cat <<EOF > /usr/share/wayland-sessions/sway-nvidia.desktop
 [Desktop Entry]
 Name=Sway-Nvidia

--- a/setup_sway_isomode.bash
+++ b/setup_sway_isomode.bash
@@ -6,10 +6,18 @@ echo "Cloning the EOS Community Sway repo..."
 git clone https://github.com/EndeavourOS-Community-Editions/sway.git
 
 # Check if nvidia-inst is installed
+# If it is, do the Nvidia stuff
 if pacman -Qq nvidia-inst 2>/dev/null | grep -q .; then
-    # If it is, do the Nvidia stuff
+    # Add the --unsupported-gpu flag to the sway call in greetd.conf
     sed -i 's|sway -c|sway --unsupported-gpu -c|' sway/etc/greetd/greetd.conf
-    
+    # Create a custom desktop file that uses sway --unsupported-gpu
+    cat <<EOF > /usr/share/wayland-sessions/sway-nvidia.desktop
+[Desktop Entry]
+Name=Sway-Nvidia
+Comment=Sway with Nvidia
+Exec=sway --unsupported-gpu
+Type=Application
+EOF
 fi
 
 # Install the custom package list

--- a/setup_sway_isomode.bash
+++ b/setup_sway_isomode.bash
@@ -28,7 +28,7 @@ EOF
 force_drivers+=" nvidia nvidia_modeset nvidia_uvm nvidia_drm "
 EOF
     echo "Regenerating initrds..."
-    dracut-rebuild
+    reinstall-kernels || dracut-rebuild
 fi
 
 # Install the custom package list

--- a/setup_sway_isomode.bash
+++ b/setup_sway_isomode.bash
@@ -8,8 +8,8 @@ git clone https://github.com/EndeavourOS-Community-Editions/sway.git
 # Check if nvidia-inst is installed
 if pacman -Qq nvidia-inst 2>/dev/null | grep -q .; then
     # If it is, do the Nvidia stuff
-#    some Nvidia stuff
-#    some other Nvidia stuff
+    sed -i 's|sway -c|sway --unsupported-gpu -c|' sway/etc/greetd/greetd.conf
+    
 fi
 
 # Install the custom package list

--- a/setup_sway_isomode.bash
+++ b/setup_sway_isomode.bash
@@ -23,6 +23,12 @@ Comment=Sway with Nvidia
 Exec=sway --unsupported-gpu
 Type=Application
 EOF
+    echo "Adding dracut config for early module loading..."
+    cat <<EOF > /etc/dracut.conf.d/nvidia-modules.conf
+force_drivers+=" nvidia nvidia_modeset nvidia_uvm nvidia_drm "
+EOF
+    echo "Regenerating initrds..."
+    dracut-rebuild
 fi
 
 # Install the custom package list

--- a/setup_sway_isomode.bash
+++ b/setup_sway_isomode.bash
@@ -27,8 +27,8 @@ EOF
     cat <<EOF > /etc/dracut.conf.d/nvidia-modules.conf
 force_drivers+=" nvidia nvidia_modeset nvidia_uvm nvidia_drm "
 EOF
-    echo "Regenerating initrds..."
-    reinstall-kernels || dracut-rebuild
+    # echo "Regenerating initrds..."
+    # reinstall-kernels || dracut-rebuild
 fi
 
 # Install the custom package list

--- a/setup_sway_isomode.bash
+++ b/setup_sway_isomode.bash
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 username="$1"
 
-# Clone the repo
-echo "Cloning the EOS Community Sway repo..."
-git clone https://github.com/EndeavourOS-Community-Editions/sway.git
+# # Clone the repo
+# echo "Cloning the EOS Community Sway repo..."
+# git clone https://github.com/EndeavourOS-Community-Editions/sway.git
+
+# Clone the nvidia-testing branch of the repo
+echo "Cloning the EOS Community Sway repo (nvidia-testing branch)..."
+git clone --branch nvidia-testing https://github.com/EndeavourOS-Community-Editions/sway.git
 
 # Check if nvidia-inst is installed
 # If it is, do the Nvidia stuff

--- a/setup_sway_isomode.bash
+++ b/setup_sway_isomode.bash
@@ -5,6 +5,13 @@ username="$1"
 echo "Cloning the EOS Community Sway repo..."
 git clone https://github.com/EndeavourOS-Community-Editions/sway.git
 
+# Check if nvidia-inst is installed
+if pacman -Qq nvidia-inst 2>/dev/null | grep -q .; then
+    # If it is, do the Nvidia stuff
+#    some Nvidia stuff
+#    some other Nvidia stuff
+fi
+
 # Install the custom package list
 echo "Installing needed packages..."
 pacman -S --noconfirm --noprogressbar --needed --disable-download-timeout $(< ./sway/packages-repository.txt)

--- a/setup_sway_isomode.bash
+++ b/setup_sway_isomode.bash
@@ -27,8 +27,8 @@ EOF
     cat <<EOF > /etc/dracut.conf.d/nvidia-modules.conf
 force_drivers+=" nvidia nvidia_modeset nvidia_uvm nvidia_drm "
 EOF
-    # echo "Regenerating initrds..."
-    # reinstall-kernels || dracut-rebuild
+    echo "Regenerating initrds..."
+    reinstall-kernels || dracut-rebuild
 fi
 
 # Install the custom package list

--- a/setup_sway_isomode.bash
+++ b/setup_sway_isomode.bash
@@ -12,9 +12,9 @@ git clone --branch nvidia-testing https://github.com/EndeavourOS-Community-Editi
 # Check if nvidia-inst is installed
 # If it is, do the Nvidia stuff
 if pacman -Qq nvidia-inst 2>/dev/null | grep -q .; then
-    # Add the --unsupported-gpu flag to the sway call in greetd.conf
+    echo "Adding the --unsupported-gpu flag to the sway call in greetd.conf..."
     sed -i 's|sway -c|sway --unsupported-gpu -c|' sway/etc/greetd/greetd.conf
-    # Create a custom desktop file that uses sway --unsupported-gpu
+    echo "Adding a custom desktop file for Nvidia sessions..."
     mkdir -p /usr/share/wayland-sessions
     cat <<EOF > /usr/share/wayland-sessions/sway-nvidia.desktop
 [Desktop Entry]


### PR DESCRIPTION
Automatically add accommodations for proprietary Nvidia drivers if the user chooses the “for latest Nvidia cards only” installation type. 

Closes https://github.com/EndeavourOS-Community-Editions/sway/issues/88