### PR TITLE
Fix lock command in power_menu.sh

### DIFF
--- a/.config/sway/scripts/power_menu.sh
+++ b/.config/sway/scripts/power_menu.sh
@@ -10,7 +10,7 @@ confirm_action() {
 
 case $SELECTION in
     *"󰌾 Lock"*)
-        swaylock;;
+        gtklock;;
     *"󰤄 Suspend"*)
         if confirm_action "Suspend"; then
             systemctl suspend


### PR DESCRIPTION
Replaced swaylock with gtklock, the currently used lock screen. Otherwise upon using this installation the lock button in the power menu does nothing.