### PR TITLE
Use variables for vim-like resize bindings

### DIFF
--- a/.config/sway/config.d/default
+++ b/.config/sway/config.d/default
@@ -163,10 +163,10 @@ set $powermenu ~/.config/sway/scripts/power_menu.sh
         $mod+ctrl+Down resize shrink height 10 px
         $mod+ctrl+Left resize grow width 10 px
         # Resize with Vim keys
-        $mod+ctrl+l resize shrink width 10 px
-        $mod+ctrl+k resize grow height 10 px
-        $mod+ctrl+j resize shrink height 10 px
-        $mod+ctrl+h resize grow width 10 px
+        $mod+ctrl+$right resize shrink width 10 px
+        $mod+ctrl+$up resize grow height 10 px
+        $mod+ctrl+$down resize shrink height 10 px
+        $mod+ctrl+$left resize grow width 10 px
     }
 
     # Resize floating windows with mouse scroll:


### PR DESCRIPTION
When the configuration moved away from resize mode and toward direct bindings, hjkl were hardcoded instead of the `$left/$right/$down/$up` variables. This just brings those bindings in line with the rest of the config. 