### PR TITLE
Power menu: omit suspend if masked

### DIFF
--- a/.config/sway/scripts/power_menu.sh
+++ b/.config/sway/scripts/power_menu.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 MENU="$(printf "󰌾 Lock\n󰤄 Suspend\n󰍃 Log out\n Reboot\n Reboot to UEFI\n󰐥 Shutdown")"
+if [[ "$(systemctl is-enabled suspend.target 2>/dev/null)" == "masked" ]]; then
+    MENU="$(echo "$MENU" | grep -v Suspend)"
+fi
 LINE_COUNT="$(printf '%s' "$MENU" | grep -c .)"
 
 SELECTION="$(printf "$MENU" | fuzzel --dmenu -a top-right -l "$LINE_COUNT" -w 18 -p "Select an option: ")"

--- a/.config/sway/scripts/power_menu.sh
+++ b/.config/sway/scripts/power_menu.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-SELECTION="$(printf "󰌾 Lock\n󰤄 Suspend\n󰍃 Log out\n Reboot\n Reboot to UEFI\n󰐥 Shutdown" | fuzzel --dmenu -a top-right -l 6 -w 18 -p "Select an option: ")"
+MENU="$(printf "󰌾 Lock\n󰤄 Suspend\n󰍃 Log out\n Reboot\n Reboot to UEFI\n󰐥 Shutdown")"
+LINE_COUNT="$(printf '%s' "$MENU" | grep -c .)"
+
+SELECTION="$(printf "$MENU" | fuzzel --dmenu -a top-right -l "$LINE_COUNT" -w 18 -p "Select an option: ")"
 
 confirm_action() {
     local action="$1"


### PR DESCRIPTION
Thanks for EOS and the pleasant Sway config!

I have a Chromebook that can't resume. Therefore I've configured it to prevent suspend, which leaves a menu item that can't possibly do anything. In such a case, let's omit the menu item.