### PR TITLE
Fix: Add XDG_CURRENT_DESKTOP to environment variables import

### DIFF
--- a/.config/sway/config.d/autostart_applications
+++ b/.config/sway/config.d/autostart_applications
@@ -9,7 +9,7 @@ exec systemctl --user import-environment DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CU
 
 # Update dbus environments with display variables
 exec hash dbus-update-activation-environment 2>/dev/null && \
-     dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK
+     dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP
 
 # Idle configuration
 exec swayidle idlehint 1

--- a/.config/sway/config.d/autostart_applications
+++ b/.config/sway/config.d/autostart_applications
@@ -5,7 +5,7 @@ exec ~/.config/sway/scripts/xed_setup.sh
 exec /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1
 
 # Import environment variables for user systemd service manager
-exec systemctl --user import-environment DISPLAY WAYLAND_DISPLAY SWAYSOCK
+exec systemctl --user import-environment DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP
 
 # Update dbus environments with display variables
 exec hash dbus-update-activation-environment 2>/dev/null && \


### PR DESCRIPTION
Fixes the issues surrounding xdg-desktop-portal-wlr not invoking due to missing environment variables. Allows for it's implementations to work again like ScreenCast and Screenshot