### PR TITLE
Add microphone mute media key binding

### DIFF
--- a/.config/sway/config.d/default
+++ b/.config/sway/config.d/default
@@ -188,6 +188,9 @@ set $powermenu ~/.config/sway/scripts/power_menu.sh
         XF86AudioLowerVolume exec pamixer -ud 2
         XF86AudioMute exec pamixer --toggle-mute
 
+        # Microphone
+        XF86AudioMicMute exec pamixer --default-source --toggle-mute
+
         # Player
         XF86AudioPlay exec playerctl play-pause
         XF86AudioNext exec playerctl next
@@ -222,4 +225,3 @@ set $powermenu ~/.config/sway/scripts/power_menu.sh
     bindsym Ctrl+Print exec ~/.config/sway/scripts/screenshot_window.sh
     # Screenshot the current display and pipe to swappy
     bindsym Shift+Print exec ~/.config/sway/scripts/screenshot_display.sh
-


### PR DESCRIPTION
## Description

Adds a microphone mute toggle for the `XF86AudioMicMute` media key to the default Sway configuration.

The default config already includes media key bindings for speaker volume and mute using `pamixer`, but it does not include a binding for microphone mute.

This adds:

```
XF86AudioMicMute exec pamixer --default-source --toggle-mute
```

## Testing

Tested on EndeavourOS with Sway. The microphone mute key correctly toggles the default microphone source between muted and unmuted.
