### PR TITLE
Turn `autotiling` into an opt-in recommendation

### DIFF
--- a/.config/sway/config.d/autostart_applications
+++ b/.config/sway/config.d/autostart_applications
@@ -22,7 +22,7 @@ exec mako
 exec_always --no-startup-id foot --server
 
 # Autotiling
-exec autotiling
+# exec autotiling
 
 # cliphist
 exec wl-paste --type text --watch cliphist store

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Alternatively, you can add Sway after the installation is complete by cloning th
 
 - If you are experiencing issues with your cursor, edit `/etc/greetd/regreet.toml` and uncomment `WLR_NO_HARDWARE_CURSORS = "1"`
  
+> [!TIP]
+> **For new users:** If you are new to sway, you may want to activate [autotiling](https://github.com/nwg-piotr/autotiling), which can offer more intuitive tiling behavior. You can do so by editing `~/.config/sway/config.d/autostart_applications`.
+>
+
 ## Get involved at our forum:
 https://forum.endeavouros.com/t/sway-edition-general-conversation
 


### PR DESCRIPTION
Addresses #115 by disabling `autotiling` per default, but recommending it to new users in the README.

Also see #117.