### PR TITLE
Warn experienced users of `autotiling`

### DIFF
--- a/.config/sway/config.d/default
+++ b/.config/sway/config.d/default
@@ -54,6 +54,7 @@ set $powermenu ~/.config/sway/scripts/power_menu.sh
 
 #
 # Moving around:
+# Note for experienced users: This repo includes "autotiling" (see config.d/autostart_applications), which may change the expected behavior of some of these keybindings.
 #
     bindsym {
         # Change window focus
@@ -116,6 +117,7 @@ set $powermenu ~/.config/sway/scripts/power_menu.sh
 
 #
 # Layout stuff:
+# Note for experienced users: This repo includes "autotiling" (see config.d/autostart_applications), which may change the expected behavior of some of these keybindings.
 #
     # Set how the current window will be split
     # Split the window vertically

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Alternatively, you can add Sway after the installation is complete by cloning th
 - Keybindings Cheatsheet: press keyboard icon in waybar
 
 - If you are experiencing issues with your cursor, edit `/etc/greetd/regreet.toml` and uncomment `WLR_NO_HARDWARE_CURSORS = "1"`
+
+> [!NOTE] 
+> **For experienced users**:  
+> This repo includes [autotiling](https://github.com/nwg-piotr/autotiling), which affects default tiling behavior. You may want to disable this in `~/.config/sway/config.d/autostart_applications`.
  
 ## Get involved at our forum:
 https://forum.endeavouros.com/t/sway-edition-general-conversation


### PR DESCRIPTION
Addresses #115 by warning experienced users of the changed behavior introduced by `autotiling`, both in the README and near relevant configuration.

Also see #116 